### PR TITLE
Rename Hass.io to Home Assistant

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         containerd.io
 # This is a development container.  Don't bother to clean up apt cache, this way we have it handy later
 
-COPY .devcontainer/start_hassio.sh /usr/local/bin/start_hassio.sh
+COPY .devcontainer/start_ha.sh /usr/local/bin/start_ha.sh
 
 # Install dependencies for the add-on development below.  For example, if you're running Node.js,
 # you may want something like the following...

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json 
 // TODO: When https://github.com/microsoft/vscode-remote-release/issues/2129 is fixed, move to ${localWorkspaceFolderBasename}\
 {
-	"name": "Hass.io Add-On",
+	"name": "Home Assistant Add-On",
 	"context": "..",
 	"dockerFile": "Dockerfile",
 	"appPort": 8123,

--- a/.devcontainer/start_ha.sh
+++ b/.devcontainer/start_ha.sh
@@ -9,7 +9,7 @@ function start_docker() {
     local starttime
     local endtime
 
-    echo "Starting docker."
+    echo "Starting docker..."
     dockerd 2> /dev/null &
     DOCKER_PID=$!
 
@@ -93,7 +93,7 @@ case "$1" in
         cleanup_hass_data || true
         exit 0;;
     *)
-        echo "Creating development Hass.io environment"
+        echo "Creating development Home Assistant environment"
         start_docker
         trap "stop_docker" ERR
         install

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Start Home Assistant",
             "type": "shell",
-            "command": "/usr/local/bin/start_hassio.sh",
+            "command": "/usr/local/bin/start_ha.sh",
             "group": {
                 "kind": "test",
                 "isDefault": true,
@@ -19,7 +19,7 @@
         },{
             "label": "Cleanup stale Home Assistant environment",
             "type": "shell",
-            "command": "/usr/local/bin/start_hassio.sh --cleanup",
+            "command": "/usr/local/bin/start_ha.sh --cleanup",
             "group": "test",
             "presentation": {
                 "reveal": "always",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Start Hass.io",
+            "label": "Start Home Assistant",
             "type": "shell",
             "command": "/usr/local/bin/start_hassio.sh",
             "group": {
@@ -17,7 +17,7 @@
             },
             "problemMatcher": []
         },{
-            "label": "Cleanup stale Hass.io environment",
+            "label": "Cleanup stale Home Assistant environment",
             "type": "shell",
             "command": "/usr/local/bin/start_hassio.sh --cleanup",
             "group": "test",
@@ -27,7 +27,7 @@
             },
             "problemMatcher": []
         },{
-            "label": "Run Hass.io CLI",
+            "label": "Run Home Assistant CLI",
             "type": "shell",
             "command": "docker run --rm -ti -v /etc/machine-id:/etc/machine-id --network=hassio --add-host hassio:172.30.32.2 homeassistant/amd64-hassio-cli:dev",
             "group": "test",

--- a/README.md
+++ b/README.md
@@ -1,53 +1,53 @@
-# Hass.io Add-on Devcontainer Template
+# Home Assistant Add-on Devcontainer Template
 
 ### Summary
 
-This is a templated to ease development of Hass.io add-ons inside of a VS Code [devcontainer](https://code.visualstudio.com/docs/remote/containers)
+This is a templated to ease development of Home Assistant add-ons inside of a VS Code [devcontainer](https://code.visualstudio.com/docs/remote/containers)
 
 ### Usage 
 
-Simply copy the contents of this repository to the base directory of the add-on you are developing.  Modify the files in the directory as needed.  
+Simply copy the contents of this repository to the base directory of the add-on you are developing. Modify the files in the directory as needed.  
 
-Your add-on will be appear in the `Local Add-ons` section of the Hass.io Add-On Store tab.
+Your add-on will be appear in the `Local Add-ons` section of the Home Assistant "Add-on store" tab.
 
 #### VS Code Tasks
 
 The following tasks are included for your convenience.
 
-- Start Hass.io
+- Start Home Assistant
 
-This task will download and run a Hass.io environment inside the container using the latest `dev` targets of Hass.io and Home Assistant.  It will be mapped to port 8123 (by default) on the host machine
+This task will download and run a Home Assistant environment inside the container using the latest `dev` targets of Home Assistant and Home Assistant Core. It will be mapped to port 8123 (by default) on the host machine.
 
-- Run Hass.io CLI - _Requires a running Hass.io_
+- Run Home Assistant CLI - _Requires a running HOme Assistant instance_
 
-This task will open a Hass.io CLI window inside VS Code
+This task will open a [Home Assistant CLI](https://github.com/home-assistant/cli) window inside VS Code.
 
-- Cleanup stale Hass.io environment
+- Cleanup stale Home Assistant environment
 
-This task will nuke the data stored by Hass.io (including the underlying Home Assistant).  Can be used to revert to a pristine state before starting Hass.io
+This task will nuke the data stored by Home Assistant (including the underlying Home Assistant Core). Can be used to revert to a pristine state before starting Home Assistant.
 
 ### FAQ
 
 Q: How do I customize some-widget-or-another?
 
-A: There is almost no "black magic" going on here.  Make sure to read up on how devcontainers work from the [official website](https://code.visualstudio.com/docs/remote/containers)
+A: There is almost no "black magic" going on here. Make sure to read up on how devcontainers work from the [official website](https://code.visualstudio.com/docs/remote/containers).
 
-Q: I read the docs.  I still need help customizing some-widget-or-another!
+Q: I read the docs. I still need help customizing some-widget-or-another!
 
-A: Come ask on [Discord](https://discordapp.com/invite/2Uath3J) in channel #hassio_dev
+A: Come ask on [Discord](https://discordapp.com/invite/2Uath3J) in channel #devs_addon or #devs_supervisor.
 
-Q: How do I develop more than one add-on in the same Hass.io instance?
+Q: How do I develop more than one add-on in the same Home Assistant instance?
 
 A: See [this issue](https://github.com/issacg/hassio-addon-devcontainer/issues/1).
 
 Q: Why are there 2 `Dockerfile`s?  
 
-A: The `.devcontainer\Dockerfile` is for your development environment.  The `Dockerfile` in the root directory is to build your Add-on.
+A: The `.devcontainer\Dockerfile` is for your development environment.  The `Dockerfile` in the root directory is to build your add-on.
 
 Q: I added `.devcontainer` to my `.dockerignore` and now things are broken.
 
-A: Don't.  The `.dockerignore` is shared by both Dockerfiles, and by adding `.devcontainer` to your `.dockerignore`, you will break things in the devcontainer.  Instead, use other means to avoid copying `.devcontainer` (and `.vscode` for that matter) in your "production" `Dockerfile`.
+A: Don't. The `.dockerignore` is shared by both Dockerfiles, and by adding `.devcontainer` to your `.dockerignore`, you will break things in the devcontainer. Instead, use other means to avoid copying `.devcontainer` (and `.vscode` for that matter) in your "production" `Dockerfile`.
 
-Q: When installing my local add-on, I'm not seeing my latest changes.  Instead, I see the functionality of the last published version of my add-on.
+Q: When installing my local add-on, I'm not seeing my latest changes. Instead, I see the functionality of the last published version of my add-on.
 
 A: Make sure that you remove the `image` key from your `config.json`, else when "installing" the add-on, it will try to use the docker image, rather than building the add-on locally.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following tasks are included for your convenience.
 
 This task will download and run a Home Assistant environment inside the container using the latest `dev` targets of Home Assistant and Home Assistant Core. It will be mapped to port 8123 (by default) on the host machine.
 
-- Run Home Assistant CLI - _Requires a running HOme Assistant instance_
+- Run Home Assistant CLI - _Requires a running Home Assistant instance_
 
 This task will open a [Home Assistant CLI](https://github.com/home-assistant/cli) window inside VS Code.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a templated to ease development of Home Assistant add-ons inside of a VS Code [devcontainer](https://code.visualstudio.com/docs/remote/containers).
 
-### Usage 
+### Usage
 
 Simply copy the contents of this repository to the base directory of the add-on you are developing. Modify the files in the directory as needed.  
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Summary
 
-This is a templated to ease development of Home Assistant add-ons inside of a VS Code [devcontainer](https://code.visualstudio.com/docs/remote/containers)
+This is a templated to ease development of Home Assistant add-ons inside of a VS Code [devcontainer](https://code.visualstudio.com/docs/remote/containers).
 
 ### Usage 
 
@@ -42,7 +42,7 @@ A: See [this issue](https://github.com/issacg/hassio-addon-devcontainer/issues/1
 
 Q: Why are there 2 `Dockerfile`s?  
 
-A: The `.devcontainer\Dockerfile` is for your development environment.  The `Dockerfile` in the root directory is to build your add-on.
+A: The `.devcontainer\Dockerfile` is for your development environment. The `Dockerfile` in the root directory is to build your add-on.
 
 Q: I added `.devcontainer` to my `.dockerignore` and now things are broken.
 


### PR DESCRIPTION
Hass.io was renamed to Home Assistant and Home Assistant to Home Assistant Core
